### PR TITLE
Internationalize blog image alt text and breadcrumb labels

### DIFF
--- a/src/components/BlogPreviewSection.tsx
+++ b/src/components/BlogPreviewSection.tsx
@@ -155,7 +155,7 @@ export function BlogPreviewSection() {
                         {post.excerpt}
                       </p>
                       <div className="inline-flex items-center justify-center gap-2 text-primary font-medium group-hover:text-primary-hover transition-colors">
-                        <span className="sr-only">Read full article: {post.title}</span>
+                        <span className="sr-only">{`${t('blog_read_full')}: ${post.title}`}</span>
                         <span aria-hidden="true">{t('blog_read_more') || 'Read Article'}</span>
                         <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
                       </div>

--- a/src/components/BlogPreviewSection.tsx
+++ b/src/components/BlogPreviewSection.tsx
@@ -119,7 +119,7 @@ export function BlogPreviewSection() {
                      <div className="aspect-video relative overflow-hidden">
                        <img 
                          src={post.featured_image_url || post.image || '/lovable-uploads/trading-strategy.jpg'} 
-                         alt={post.imageAlt || `Professional trading education article: ${post.title}`}
+                         alt={post.imageAlt || `${t('blog_article_image_alt')}: ${post.title}`}
                          className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-500"
                          loading="lazy"
                          decoding="async"

--- a/src/components/BreadcrumbNavigation.tsx
+++ b/src/components/BreadcrumbNavigation.tsx
@@ -19,7 +19,7 @@ function getRouteLabel(path: string, content: any) {
   const pages = content?.pages || {};
   switch (path) {
     case '/':
-      return 'Home';
+      return content?.navigation?.links?.find((l: any) => l.href === '/')?.name ?? pages.home?.title ?? 'Home';
     case '/about':
       return pages.about?.title ?? 'About';
     case '/strategy':
@@ -27,19 +27,19 @@ function getRouteLabel(path: string, content: any) {
     case '/services':
       return content?.services?.title ?? 'Services';
     case '/services/learn':
-      return 'Learn';
+      return content?.services?.title ? `${content?.services?.title} - Learn` : 'Learn';
     case '/mentorship':
       return pages.contact?.title ?? 'Mentorship';
     case '/placement-quiz':
       return 'Placement Quiz';
     case '/blog':
-      return pages.blog?.title ?? 'Blog';
+      return pages.blog?.title ?? content?.blogPreview?.title ?? 'Blog';
     case '/faqs':
       return pages.faqs?.title ?? 'FAQs';
     case '/contact':
       return pages.contact?.title ?? 'Contact';
     case '/resources':
-      return 'Resources';
+      return content?.resources?.title ?? 'Resources';
     case '/lp/drive-education':
       return 'Drive Education';
     case '/privacy-policy':

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -211,10 +211,8 @@ export const translations: Record<Locale, Record<string, string>> = {
     // Blog page
     blog_hero_title: 'Trading Education Blog',
     blog_hero_subtitle: 'Educational insights, market analysis, and practical trading knowledge to help you develop disciplined trading habits.',
-
-    // Blog (French)
-    blog_hero_title_fr: 'Blog d\'éducation au trading',
-    blog_hero_subtitle_fr: 'Aperçus pédagogiques, analyses de marché et connaissances pratiques pour vous aider à développer des habitudes de trading disciplinées.',
+    blog_hero_image_alt: 'Professional forex trading analysis workspace with multiple monitors displaying trading charts',
+    blog_article_image_alt: 'Professional trading education article image',
     blog_educational_note: 'Educational Content Only:',
     blog_educational_note_desc: 'All articles are for educational purposes. Not financial advice. Trading involves risk of loss.',
     blog_category_all: 'All',
@@ -453,6 +451,8 @@ export const translations: Record<Locale, Record<string, string>> = {
     // Blog page
     blog_hero_title: 'Blog d\'éducation au trading',
     blog_hero_subtitle: 'Aperçus pédagogiques, analyses de marché et connaissances pratiques pour vous aider à développer des habitudes de trading disciplinées.',
+    blog_hero_image_alt: 'Espace de travail d’analyse de trading forex avec plusieurs écrans affichant des graphiques',
+    blog_article_image_alt: "Image d'article d'éducation au trading professionnel",
     blog_read_more: 'Lire la suite',
 
     // Blog listing helpers

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -150,23 +150,23 @@ const Blog = () => {
           <div className="container px-4">
             <div className="max-w-4xl mx-auto text-center">
               <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-6">
-                Stay Updated with Our Newsletter
+                {t('newsletter_title')}
               </h2>
               <p className="text-xl text-muted-foreground mb-8">
-                Get weekly market insights, educational content, and trading tips delivered to your inbox.
+                {t('newsletter_subtitle')}
               </p>
               <div className="flex flex-col sm:flex-row gap-4 max-w-md mx-auto">
-                <input 
-                  type="email" 
-                  placeholder="Enter your email" 
+                <input
+                  type="email"
+                  placeholder={t('newsletter_email_placeholder')}
                   className="flex-1 px-4 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary bg-background/80 backdrop-blur-sm"
                 />
                 <Button variant="hero" className="px-6 py-2">
-                  Subscribe
+                  {t('newsletter_subscribe')}
                 </Button>
               </div>
               <p className="text-sm text-muted-foreground mt-4">
-                No spam. Educational content only. Unsubscribe anytime.
+                {t('newsletter_note')}
               </p>
             </div>
           </div>

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -25,14 +25,14 @@ const Blog = () => {
         {/* Hero Section */}
         <section className="relative py-20 overflow-hidden">
           <div className="absolute inset-0 hero-image">
-            <img 
-              src={forexBlogHero} 
-              alt="Professional forex trading analysis workspace with multiple monitors displaying trading charts" 
+            <img
+              src={forexBlogHero}
+              alt={t('blog_hero_image_alt')}
               className="w-full h-full object-cover"
               loading="eager"
               width={1920}
               height={1080}
-              
+
               onError={(e) => {
                 console.warn('Hero image failed to load');
                 (e.target as HTMLImageElement).style.display = 'none';

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -10,64 +10,11 @@ import { Calendar, User, ArrowRight } from "lucide-react";
 import forexBlogHero from "@/assets/forex-blog-hero.jpg";
 import { useI18n } from '@/i18n';
 
-const blogPosts = [
-  {
-    title: "Understanding Market Structure: A Beginner's Guide",
-    excerpt: "Learn the fundamentals of market structure and how institutional traders view price movements. This comprehensive guide covers the basics of support and resistance, trend analysis, and key levels that drive market behavior.",
-    category: "Education",
-    date: "March 15, 2024",
-    author: "KenneDyne spot Team",
-    readTime: "5 min read",
-    featured: true
-  },
-  {
-    title: "Risk Management: The Foundation of Successful Trading",
-    excerpt: "Why proper risk management is more important than finding the perfect setup. Discover how to calculate position sizes, set stop losses, and manage your trading capital effectively.",
-    category: "Risk Management", 
-    date: "March 10, 2024",
-    author: "KenneDyne spot Team",
-    readTime: "7 min read",
-    featured: true
-  },
-  {
-    title: "The Psychology of Trading: Overcoming Common Mental Traps",
-    excerpt: "How to develop the discipline and mindset needed for consistent trading performance. Learn about FOMO, overconfidence, and other psychological barriers that affect traders.",
-    category: "Psychology",
-    date: "March 5, 2024", 
-    author: "KenneDyne spot Team",
-    readTime: "6 min read",
-    featured: false
-  },
-  {
-    title: "Smart Money Concepts: Following Institutional Flow",
-    excerpt: "Understanding how banks and institutions move the market and how retail traders can align with these movements through proper analysis.",
-    category: "Education",
-    date: "February 28, 2024",
-    author: "KenneDyne spot Team", 
-    readTime: "8 min read",
-    featured: false
-  },
-  {
-    title: "Building Your Trading Journal: Track Progress Not Just Profits",
-    excerpt: "Why keeping a detailed trading journal is crucial for improvement and how to structure it effectively for maximum learning benefit.",
-    category: "Education",
-    date: "February 20, 2024",
-    author: "KenneDyne spot Team",
-    readTime: "4 min read", 
-    featured: false
-  },
-  {
-    title: "Common Trading Mistakes and How to Avoid Them",
-    excerpt: "Learn from the most frequent errors that derail trading accounts and develop habits that promote long-term success.",
-    category: "Education",
-    date: "February 15, 2024",
-    author: "KenneDyne spot Team",
-    readTime: "6 min read",
-    featured: false
-  }
-];
+import { useSiteContent } from '@/hooks/useSiteContent';
 
-const categories = ["All", "Education", "Risk Management", "Psychology"];
+const { content } = useSiteContent();
+const blogPosts = content.blogPreview.posts || [];
+const categories = content.blogPreview.categories || [];
 
 const Blog = () => {
   const { t } = useI18n();

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -12,12 +12,12 @@ import { useI18n } from '@/i18n';
 
 import { useSiteContent } from '@/hooks/useSiteContent';
 
-const { content } = useSiteContent();
-const blogPosts = content.blogPreview.posts || [];
-const categories = content.blogPreview.categories || [];
-
 const Blog = () => {
   const { t } = useI18n();
+  const { content } = useSiteContent();
+  const blogPosts = content.blogPreview.posts || [];
+  const categories = content.blogPreview.categories || [];
+
   return (
     <div className="min-h-screen bg-background">
       <Navigation />

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -58,9 +58,9 @@ const Blog = () => {
               {/* Category Filter */}
               <div className="flex flex-wrap gap-4 justify-center mb-12">
                 {categories.map((category) => (
-                  <Badge 
-                    key={category} 
-                    variant={category === "All" ? "default" : "secondary"}
+                  <Badge
+                    key={category}
+                    variant={category === (content.blogPreview.categories?.[0] || 'All') ? "default" : "secondary"}
                     className="cursor-pointer hover:bg-primary hover:text-primary-foreground transition-all duration-200 px-4 py-2 rounded-full shadow-sm hover:shadow-md hover:-translate-y-0.5"
                   >
                     {category}

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -426,7 +426,7 @@ export default function BlogPost() {
                   <div className="aspect-video mb-8 rounded-lg overflow-hidden">
                     <img
                       src={post.featured_image_url}
-                      alt={post.title}
+                      alt={`${t('blog_article_image_alt')}: ${post.title}` }
                       className="w-full h-full object-cover"
                       loading="eager"
                     />

--- a/src/pages/BlogPublic.tsx
+++ b/src/pages/BlogPublic.tsx
@@ -245,7 +245,7 @@ export default function BlogPublic() {
           <div className="absolute inset-0 hero-image">
             <img 
               src={forexBlogHero} 
-              alt="Professional forex trading analysis workspace with multiple monitors displaying trading charts" 
+              alt={t('blog_hero_image_alt')} 
               className="w-full h-full object-cover"
               loading="eager"
               width={1920}

--- a/src/pages/BlogPublic.tsx
+++ b/src/pages/BlogPublic.tsx
@@ -373,7 +373,7 @@ export default function BlogPublic() {
                         {post.featured_image_url ? (
                           <img
                             src={post.featured_image_url}
-                            alt={post.title}
+                            alt={`${t('blog_article_image_alt')}: ${post.title}` }
                             className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
                           />
                         ) : (
@@ -451,7 +451,7 @@ export default function BlogPublic() {
                         {post.featured_image_url ? (
                           <img
                             src={post.featured_image_url}
-                            alt={post.title}
+                            alt={`${t('blog_article_image_alt')}: ${post.title}` }
                             className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
                           />
                         ) : (


### PR DESCRIPTION
## Purpose
The user requested to continue with internationalization improvements, specifically focusing on making the blog section more accessible and translatable by replacing hardcoded English text with internationalized strings.

## Code changes
- **Blog image alt text**: Replaced hardcoded "Professional trading education article" with translatable `blog_article_image_alt` key in BlogPreviewSection, BlogPost, and BlogPublic components
- **Hero image alt text**: Updated blog hero image alt text to use `blog_hero_image_alt` translation key
- **Screen reader text**: Internationalized "Read full article" screen reader text using `blog_read_full` key
- **Breadcrumb navigation**: Enhanced breadcrumb labels to use dynamic content from site configuration instead of hardcoded strings for better localization support
- **Translation keys**: Added new translation keys for blog image alt text in both English and French locales
- **Blog data source**: Updated Blog component to use dynamic content from `useSiteContent` hook instead of hardcoded blog posts array

These changes improve accessibility and internationalization by ensuring all user-facing text can be properly translated and customized based on site content configuration.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/45270ca3da334034a4ee7fb1b77f5ab5/neon-space)

👀 [Preview Link](https://45270ca3da334034a4ee7fb1b77f5ab5-neon-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>45270ca3da334034a4ee7fb1b77f5ab5</projectId>-->
<!--<branchName>neon-space</branchName>-->