### PR TITLE
Standardize CTA buttons with theme colors across pages

### DIFF
--- a/src/components/FinalCTASection.tsx
+++ b/src/components/FinalCTASection.tsx
@@ -30,7 +30,6 @@ export function FinalCTASection() {
               <a
                 {...getExternalLinkProps(LINKS.exness.signup)}
                 aria-label={button.text}
-                className="px-8 py-3 rounded-full bg-gradient-primary text-white font-semibold shadow-button"
               >
                 {button.text}
               </a>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80 shadow-card",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
-        hero: "bg-white text-primary border border-white/10 hover:bg-white/90 shadow-button transform hover:scale-105 font-semibold",
+        hero: "bg-primary text-primary-foreground hover:bg-primary-hover shadow-button hover:shadow-elevation transform hover:scale-105 font-semibold",
         white: "bg-white text-primary border border-white/10 hover:bg-white/90 shadow-button transform hover:scale-105 font-semibold",
         purple: "bg-gradient-primary text-white border border-primary/20 hover:shadow-elevation shadow-button transform hover:scale-105 hover:shadow-button font-semibold",
         glass: "bg-card/20 backdrop-blur-md border border-white/10 text-foreground hover:bg-card/30 shadow-glass",

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -124,7 +124,7 @@ const Contact = () => {
                 }}>
                   <Mail className="h-4 w-4 mr-2" /> {t('contact_email_us')}
                 </Button>
-                <Button asChild variant="glass" size="lg" className="border-white/30 text-white hover:bg-white/10">
+                <Button asChild variant="outline" size="lg">
                   <a {...getExternalLinkProps(whatsappUrl)}>
                     <MessageCircle className="h-4 w-4 mr-2" /> {t('contact_whatsapp')}
                   </a>

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -228,7 +228,7 @@ export default function Learn() {
                       </Button>
 
                       {path.priceValue && path.priceValue > 0 && (
-                        <Button variant="white" className="w-full" size="lg" onClick={() => openPayment(path.priceValue, path.title)}>
+                        <Button variant="default" className="w-full" size="lg" onClick={() => openPayment(path.priceValue, path.title)}>
                           Pay {path.price}
                         </Button>
                       )}

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -84,18 +84,17 @@ export function Services() {
             <p className="text-lg max-w-4xl mx-auto mb-8">{t('services_hero_paragraph')}</p>
             
             <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-              <Button 
+              <Button
                 asChild
                 size="lg"
-                className="bg-white text-primary hover:bg-white/90 font-semibold px-8"
+                variant="default"
               >
                 <Link to="#services" className="flex items-center gap-2">{t('services_cta_explore')}<ArrowDown className="h-4 w-4" /></Link>
               </Button>
-              <Button 
+              <Button
                 asChild
                 variant="outline"
                 size="lg"
-                className="border-white/30 text-white hover:bg-white/10 backdrop-blur-sm px-8"
               >
                 <Link to="/mentorship" className="flex items-center gap-2"><MessageCircle className="h-4 w-4" />{t('services_cta_talk_mentor')}</Link>
               </Button>


### PR DESCRIPTION
## Purpose
Audit and standardize all CTA buttons across the application to ensure consistent styling based on the established theme colors. This improves visual consistency and user experience throughout the site.

## Code changes
- **FinalCTASection.tsx**: Removed inline styling from CTA link to rely on component variants
- **button.tsx**: Updated `hero` variant to use primary theme colors instead of white background
- **Contact.tsx**: Changed WhatsApp button from `glass` variant to `outline` variant for better consistency
- **Learn.tsx**: Updated payment button from `white` variant to `default` variant
- **Services.tsx**: Standardized hero section buttons to use `default` and `outline` variants, removing custom inline styling

All changes ensure CTA buttons follow the established design system and theme color palette.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 23`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f7103950e7ff4c448181edaae83bf6fb/echo-garden)

👀 [Preview Link](https://f7103950e7ff4c448181edaae83bf6fb-echo-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f7103950e7ff4c448181edaae83bf6fb</projectId>-->
<!--<branchName>echo-garden</branchName>-->